### PR TITLE
Add logout documentation

### DIFF
--- a/content/documentation/moreDocumentation/content.md
+++ b/content/documentation/moreDocumentation/content.md
@@ -213,4 +213,4 @@ const logoutUrl = `./oauth2/sign_out?rd=${encodedKeycloakUrl}`;
 For more information on the relevant logout endpoints, refer to the following resources:
 
 - [OAuth2 Proxy Logout Endpoint Documentation](https://oauth2-proxy.github.io/oauth2-proxy/features/endpoints#sign-out)
-- [Keycloak OpenID Connect Logout Endpoint Documentation](https://www.keycloak.org/docs/latest/securing_apps/#logout-endpoint)
+- [Keycloak OpenID Connect Logout Endpoint Documentation](https://www.keycloak.org/securing-apps/oidc-layers#_endpoints)


### PR DESCRIPTION
Add documentation how to create a logout URL that clears Keycloak and OAuth cookies.

Note: This requires version 0.12.0-next.4 of the theia-cloud helm chart to work