### PR TITLE
Fix repository URLs for move to Eclipse Foundation

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -83,7 +83,7 @@ lastmod = ["lastmod", ":git", "date"]
   weight = 60
 
 [[menu.main]]
-  url = "https://github.com/eclipsesource/theia-cloud"
+  url = "https://github.com/eclipse-theia/theia-cloud"
   name = "GitHub"
   weight = 60
 
@@ -142,10 +142,10 @@ lastmod = ["lastmod", ":git", "date"]
   weight = 30
   name = "github"
   pre = "fab fa-github"
-  url = "https://github.com/eclipsesource/theia-cloud"
+  url = "https://github.com/eclipse-theia/theia-cloud"
 
 [[menu.footer_social]]
   weight = 30
   name = "github-discussions"
   pre = "far fa-comments"
-  url = "https://github.com/eclipsesource/theia-cloud/discussions"
+  url = "https://github.com/eclipse-theia/theia-cloud/discussions"

--- a/content/contact/contactoptions/issues.md
+++ b/content/contact/contactoptions/issues.md
@@ -7,4 +7,4 @@ weight = 50
   url = ""
 +++
 
-Please use our [GitHub repository](https://github.com/eclipsesource/theia-cloud) to report features requests and bugs.
+Please use our [GitHub repository](https://github.com/eclipse-theia/theia-cloud) to report features requests and bugs.

--- a/content/contact/contactoptions/spektrum.md
+++ b/content/contact/contactoptions/spektrum.md
@@ -4,7 +4,7 @@ weight = 10
 
 [asset]
   icon = "far fa-comments"
-  url = "https://github.com/eclipsesource/theia-cloud/discussions"
+  url = "https://github.com/eclipse-theia/theia-cloud/discussions"
 +++
 
-Get in contact with the team, ask questions and browse the support archive in our [Github Discussions](https://github.com/eclipsesource/theia-cloud/discussions).
+Get in contact with the team, ask questions and browse the support archive in our [Github Discussions](https://github.com/eclipse-theia/theia-cloud/discussions).

--- a/content/documentation/addApplication/content.md
+++ b/content/documentation/addApplication/content.md
@@ -136,7 +136,7 @@ To include it in your application, simply add `@eclipse-theiacloud/monitor-theia
 
 ```
 
-For an example of how to implement this, consider our [test sample application](https://github.com/eclipsesource/theia-cloud/tree/main/demo/dockerfiles/demo-theia-monitor-theia).
+For an example of how to implement this, consider our [test sample application](https://github.com/eclipse-theia/theia-cloud/tree/main/demo/dockerfiles/demo-theia-monitor-theia).
 
 ### VS Code Extension
 
@@ -144,7 +144,7 @@ Alternatively, you may opt for the Theia Cloud Monitor VS Code extension.
 This extension relies on the VSCode API for activity detection, which may not be as effective as the Theia Extension method.
 Therefore, we recommend using the Theia Extension over the VS Code extension.
 The `*.vsix` file for this extension can be downloaded from our GitHub Releases page.
-For instance, for release 0.9.0, the extension is available [here](https://github.com/eclipsesource/theia-cloud/releases/download/0.9.0/theiacloud-monitor-0.9.0.vsix).
+For instance, for release 0.9.0, the extension is available [here](https://github.com/eclipse-theia/theia-cloud/releases/download/0.9.0/theiacloud-monitor-0.9.0.vsix).
 
 <img src="../../images/logo.png" alt="Theia Cloud Logo" width="100" style="display: block; margin: auto;" />
 
@@ -200,7 +200,7 @@ spec:
 
 - **`port`**: The port on which Theia runs.
 
-- **`ingressname`**: Defines the ingress resource to be patched for exposing new application sessions. Typically, this should match the `ingress.instanceName` used during the `theia-cloud` helm chart installation. For the default value, see [theia-cloud helm chart details](https://github.com/eclipsesource/theia-cloud-helm/tree/main/charts/theia-cloud).
+- **`ingressname`**: Defines the ingress resource to be patched for exposing new application sessions. Typically, this should match the `ingress.instanceName` used during the `theia-cloud` helm chart installation. For the default value, see [theia-cloud helm chart details](https://github.com/eclipse-theia/theia-cloud-helm/tree/main/charts/theia-cloud).
 
 - **`minInstances`**: Currently, this should be 0. Future versions may support pre-launching sessions for incoming users. _If you need this feature earlier, explore our [support options]({{< relref "/support" >}})._
 

--- a/content/documentation/customizeTheiaCloud/content.md
+++ b/content/documentation/customizeTheiaCloud/content.md
@@ -18,7 +18,7 @@ As a result, providing a fully white-labeled dashboard often does not meet all t
 Therefore, Theia Cloud focuses on providing TypeScript APIs and libraries that allow users to easily interact with Theia Cloud Services.
 This approach enables users to create their own landing page or to integrate Theia Cloud in existing web applications.
 
-To get started or for demonstration purposes, you may want to explore [our sample landing page](https://github.com/eclipsesource/theia-cloud/tree/main/node/landing-page).
+To get started or for demonstration purposes, you may want to explore [our sample landing page](https://github.com/eclipse-theia/theia-cloud/tree/main/node/landing-page).
 
 ### Simple Customizations
 
@@ -42,8 +42,8 @@ landingPage:
 
 Additionally, the SVG image displayed on the try-now page can be changed via the `landingPage.logoData` property. This property expects a base64 encoded SVG image. For example, you can encode an SVG to base64 using `cat path/to/file.svg | base64 -w 0 -`.
 
-If you want to make small changes to the wording, please check out the repository ([try now page](https://github.com/eclipsesource/theia-cloud/tree/main/node/landing-page), [components](https://github.com/eclipsesource/theia-cloud/tree/main/node/landing-page/src/components)).
-Instructions for containerizing the web site can be foud [here](https://github.com/eclipsesource/theia-cloud/blob/main/documentation/Building.md).
+If you want to make small changes to the wording, please check out the repository ([try now page](https://github.com/eclipse-theia/theia-cloud/tree/main/node/landing-page), [components](https://github.com/eclipse-theia/theia-cloud/tree/main/node/landing-page/src/components)).
+Instructions for containerizing the web site can be foud [here](https://github.com/eclipse-theia/theia-cloud/blob/main/documentation/Building.md).
 The custom image can be specified as `landingPage.image`.
 
 <img src="../../images/logo.png" alt="Theia Cloud Logo" width="100" style="display: block; margin: auto;" />

--- a/content/documentation/moreDocumentation/content.md
+++ b/content/documentation/moreDocumentation/content.md
@@ -25,7 +25,7 @@ It offers to provide environment variables directly or as lists of [config maps]
 The following code snippet shows how to add environment variables while starting a session.
 Thereby, the whole `env` as well as its three properties `fromMap`, `fromConfigMaps` and `fromSecrets` are optional.
 The snippet assumes that the parameters `accessToken` and `user` are present as variables based on the authenticated user.
-You can have a look at the [Try Now Page](https://github.com/eclipsesource/theia-cloud/blob/main/node/landing-page/src/App.tsx) to see an example of how these are derived when logging in via Keycloak.
+You can have a look at the [Try Now Page](https://github.com/eclipse-theia/theia-cloud/blob/main/node/landing-page/src/App.tsx) to see an example of how these are derived when logging in via Keycloak.
 
 ```typescript
 import {
@@ -62,11 +62,11 @@ TheiaCloud.Session.startSession(request);
 
 The environment variables can also be configured directly through the Session custom resource by adding one or multiple of the following properties:
 
-- [envVars](https://github.com/eclipsesource/theia-cloud-helm/blob/4cd9d98d30cebe8d31e7084369878c1c2d28776c/charts/theia-cloud-crds/templates/session-spec-resource.yaml#L46-L49): This property is a map that allows you to define environment variables directly. Each entry in the map consists of the environment variable name and its value. This method is suitable for standard configuration needs and facilitates individual configuration for each session.
+- [envVars](https://github.com/eclipse-theia/theia-cloud-helm/blob/4cd9d98d30cebe8d31e7084369878c1c2d28776c/charts/theia-cloud-crds/templates/session-spec-resource.yaml#L46-L49): This property is a map that allows you to define environment variables directly. Each entry in the map consists of the environment variable name and its value. This method is suitable for standard configuration needs and facilitates individual configuration for each session.
 
-- [envVarsFromConfigMaps](https://github.com/eclipsesource/theia-cloud-helm/blob/4cd9d98d30cebe8d31e7084369878c1c2d28776c/charts/theia-cloud-crds/templates/session-spec-resource.yaml#L50-L53): For environment variables that need to be sourced from existing Kubernetes config maps, this property allows you to specify a list of config maps from which to read. This approach is particularly useful for sharing common configuration across multiple sessions or applications.
+- [envVarsFromConfigMaps](https://github.com/eclipse-theia/theia-cloud-helm/blob/4cd9d98d30cebe8d31e7084369878c1c2d28776c/charts/theia-cloud-crds/templates/session-spec-resource.yaml#L50-L53): For environment variables that need to be sourced from existing Kubernetes config maps, this property allows you to specify a list of config maps from which to read. This approach is particularly useful for sharing common configuration across multiple sessions or applications.
 
-- [envVarsFromSecrets](https://github.com/eclipsesource/theia-cloud-helm/blob/4cd9d98d30cebe8d31e7084369878c1c2d28776c/charts/theia-cloud-crds/templates/session-spec-resource.yaml#L54-L57): Similar to `envVarsFromConfigMaps`, this property lets you define a list of Kubernetes secrets from which to read environment variables. This method is a good fit for sensitive information such as credentials, ensuring that such details are managed securely and in accordance with Kubernetes best practices.
+- [envVarsFromSecrets](https://github.com/eclipse-theia/theia-cloud-helm/blob/4cd9d98d30cebe8d31e7084369878c1c2d28776c/charts/theia-cloud-crds/templates/session-spec-resource.yaml#L54-L57): Similar to `envVarsFromConfigMaps`, this property lets you define a list of Kubernetes secrets from which to read environment variables. This method is a good fit for sensitive information such as credentials, ensuring that such details are managed securely and in accordance with Kubernetes best practices.
 
 #### Accessing environment variables in Theia
 
@@ -115,7 +115,7 @@ The key components of this pattern are:
 
 Our default installation includes basic support for Let's Encrypt certificates.
 However, more advanced use cases, such as wildcard certificates, require specific configuration allowing the cert-manager to update DNS entries (see [here](https://cert-manager.io/docs/configuration/acme/dns01/)) to obtain valid certificates from Let's Encrypt.
-To support this, you can create your own cluster issuer and pass the name to Theia Cloud using the [`ingress.clusterIssuer` helm value](https://github.com/eclipsesource/theia-cloud-helm/tree/main/charts/theia-cloud#readme).
+To support this, you can create your own cluster issuer and pass the name to Theia Cloud using the [`ingress.clusterIssuer` helm value](https://github.com/eclipse-theia/theia-cloud-helm/tree/main/charts/theia-cloud#readme).
 
 In a production environment, you often have existing certificates you want to use.
 For this, we have the `ingress.certManagerAnnotations` helm value, which can be set to `false` to avoid adding any cert-manager-related annotations on the ingress.

--- a/content/documentation/setupTheiaCloud/content.md
+++ b/content/documentation/setupTheiaCloud/content.md
@@ -21,7 +21,7 @@ Theia Cloud depends on well-established software in the Kubernetes ecosystem.
 We won't go into full detail explaining how to install each dependency but will provide links to their official documentation.
 
 Please note that our [Try Theia Cloud]({{< relref "tryTheiaCloud" >}}) guides use Terraform charts that will install all requirements automatically.
-Please have a look at their [Helm configuration](https://github.com/eclipsesource/theia-cloud/blob/main/terraform/modules/helm/main.tf) to find the values used in the getting started guides.
+Please have a look at their [Helm configuration](https://github.com/eclipse-theia/theia-cloud/blob/main/terraform/modules/helm/main.tf) to find the values used in the getting started guides.
 
 ### cert-manager.io
 
@@ -78,7 +78,7 @@ We aim to make the contents of these charts as customizable as possible.
 This includes providing options to skip any optional resources during installation.
 This guide provides an overview of each Helm chart along with sample configurations.
 For comprehensive configuration options, refer to the linked documentation within each section.
-Additionally, explore our [Terraform configurations](https://github.com/eclipsesource/theia-cloud/tree/main/terraform/configurations) for complete Theia Cloud setups on various cluster providers, including GKE and Minikube.
+Additionally, explore our [Terraform configurations](https://github.com/eclipse-theia/theia-cloud/tree/main/terraform/configurations) for complete Theia Cloud setups on various cluster providers, including GKE and Minikube.
 For early access to customization options, new terraform examples, or if you require specific changes, please consult our [support options]({{< relref "/support" >}}).
 
 ### theia-cloud-base
@@ -99,7 +99,7 @@ Install the chart using:
 helm install my-theia-cloud-base theia-cloud-repo/theia-cloud-base -f base-values.yaml
 ```
 
-For a full list of customizable values, visit [theia-cloud-base chart documentation](https://github.com/eclipsesource/theia-cloud-helm/blob/main/charts/theia-cloud-base/README.md).
+For a full list of customizable values, visit [theia-cloud-base chart documentation](https://github.com/eclipse-theia/theia-cloud-helm/blob/main/charts/theia-cloud-base/README.md).
 
 ### theia-cloud-crds
 
@@ -113,7 +113,7 @@ kubectl create namespace my-namespace
 helm -n my-namespace install my-theia-cloud-crds theia-cloud-repo/theia-cloud-crds
 ```
 
-Refer to [theia-cloud-crds chart documentation](https://github.com/eclipsesource/theia-cloud-helm/blob/main/charts/theia-cloud-crds/README.md) for customization details.
+Refer to [theia-cloud-crds chart documentation](https://github.com/eclipse-theia/theia-cloud-helm/blob/main/charts/theia-cloud-crds/README.md) for customization details.
 
 ### theia-cloud
 
@@ -175,8 +175,8 @@ status:
 minikube ip
 ```
 
-- Keycloak Integration: By setting `keycloak.enable` to `false`, you opt out of Keycloak integration. If you wish to utilize Keycloak for authentication, further configuration will be necessary. Please check out the options [here](https://github.com/eclipsesource/theia-cloud-helm/blob/main/charts/theia-cloud/README.md) to learn about all Keycloak options.\
-  For configuring Keycloak itself please have a look at the [oauth2-proxy documentation](https://oauth2-proxy.github.io/oauth2-proxy/configuration/providers/keycloak_oidc) and our [terraform Keycloak Example Realm configuration](https://github.com/eclipsesource/theia-cloud/blob/main/terraform/modules/keycloak/main.tf).
+- Keycloak Integration: By setting `keycloak.enable` to `false`, you opt out of Keycloak integration. If you wish to utilize Keycloak for authentication, further configuration will be necessary. Please check out the options [here](https://github.com/eclipse-theia/theia-cloud-helm/blob/main/charts/theia-cloud/README.md) to learn about all Keycloak options.\
+  For configuring Keycloak itself please have a look at the [oauth2-proxy documentation](https://oauth2-proxy.github.io/oauth2-proxy/configuration/providers/keycloak_oidc) and our [terraform Keycloak Example Realm configuration](https://github.com/eclipse-theia/theia-cloud/blob/main/terraform/modules/keycloak/main.tf).
 - Cloud Provider Configuration: Adjust `operator.cloudProvider` to `MINIKUBE` if running on Minikube or leave the current value `K8S` for other clusters.
 - Ingress and Security: `ingress.clusterIssuer` may have to be adjusted if a different issuer than the Let's encrypt issuer should be used or if it was installed with a different name. `ingress.theiaCloudCommonName` may have to be adjusted if the certificate created by the issuer misses the common name property.
 - Roles Configuration: `operatorrole` and `servicerole` names might need adjustments if you adjusted the name during the base chart installation
@@ -189,7 +189,7 @@ helm -n my-namespace install my-theia-cloud theia-cloud-repo/theia-cloud -f valu
 
 This setup enables access to the Theia Cloud sample landing page at <https://12.345.67.89.sslip.io/trynow/>.
 
-For detailed installation instructions and customization options, visit [the main Theia Cloud chart documentation](https://github.com/eclipsesource/theia-cloud-helm/blob/main/charts/theia-cloud/README.md).
+For detailed installation instructions and customization options, visit [the main Theia Cloud chart documentation](https://github.com/eclipse-theia/theia-cloud-helm/blob/main/charts/theia-cloud/README.md).
 
 <img src="../../images/logo.png" alt="Theia Cloud Logo" width="100" style="display: block; margin: auto;" />
 
@@ -199,7 +199,7 @@ This section explains how to update your Theia Cloud deployment.
 This includes updating values as well as upgrading to a new Theia Cloud version.
 Similar to the installation, Helm is used for this.
 
-Before moving to a new Theia Cloud version, you might want to have a look at the [Theia Cloud Helm changelog](https://github.com/eclipsesource/theia-cloud-helm/blob/main/CHANGELOG.md). If you customized core components (e.g. the operator), you also might want to look at [Theia Cloud's code changelog](https://github.com/eclipsesource/theia-cloud/blob/main/CHANGELOG.md).
+Before moving to a new Theia Cloud version, you might want to have a look at the [Theia Cloud Helm changelog](https://github.com/eclipse-theia/theia-cloud-helm/blob/main/CHANGELOG.md). If you customized core components (e.g. the operator), you also might want to look at [Theia Cloud's code changelog](https://github.com/eclipse-theia/theia-cloud/blob/main/CHANGELOG.md).
 
 Make sure you have the Theia Cloud helm charts available and updated as described in section [Theia Cloud Helm Charts](#theia-cloud-helm-charts).
 In short:

--- a/content/documentation/try/gke/content.md
+++ b/content/documentation/try/gke/content.md
@@ -40,7 +40,7 @@ Our terraform modules expect you to have the Google Cloud SDK installed and set 
 Finally, please check out our git repository. The repository contains the terraform configuration files used in this guide.
 
 ```bash
-git clone https://github.com/eclipsesource/theia-cloud.git
+git clone https://github.com/eclipse-theia/theia-cloud.git
 ```
 
 #### Run the Getting Started Guide

--- a/content/documentation/try/minikube/content.md
+++ b/content/documentation/try/minikube/content.md
@@ -51,7 +51,7 @@ You can download and install Terraform as described here: <https://developer.has
 Finally, please check out our git repository. The repository contains the terraform configuration files used in this guide.
 
 ```bash
-git clone https://github.com/eclipsesource/theia-cloud.git
+git clone https://github.com/eclipse-theia/theia-cloud.git
 ```
 
 #### Run the Getting Started Guide

--- a/content/releases/content.md
+++ b/content/releases/content.md
@@ -8,10 +8,10 @@ background = "white"
 
 <img src="../images/logo.png" alt="Theia Cloud Logo" width="100" style="display: block; margin: auto;" />
 
-The release notes for Theia Cloud are available on [Github](https://github.com/eclipsesource/theia-cloud/releases).\
+The release notes for Theia Cloud are available on [Github](https://github.com/eclipse-theia/theia-cloud/releases).\
 There you can find detailed information about our new releases, changelogs, and breaking changes.
 
-To get notified about new releases, please [watch us on Github](https://github.com/eclipsesource/theia-cloud/).
+To get notified about new releases, please [watch us on Github](https://github.com/eclipse-theia/theia-cloud/).
 
 ### Available Resources
 

--- a/content/support/examples/freesupport.md
+++ b/content/support/examples/freesupport.md
@@ -4,10 +4,10 @@ weight = 10
 
 [asset]
   icon = "far fa-hand-point-right"
-  url = "https://github.com/eclipsesource/theia-cloud/discussions"
+  url = "https://github.com/eclipse-theia/theia-cloud/discussions"
 +++
 
-[Public channel](https://github.com/eclipsesource/theia-cloud/discussions)\
+[Public channel](https://github.com/eclipse-theia/theia-cloud/discussions)\
 Basic topics only\
 Longer response time
 


### PR DESCRIPTION
Adapt all repository URLs from the Eclipsesource to the Eclipse Theia organization.