### PR TITLE
1.2.0 Release: Document HAProxy as default ingress controller

### DIFF
--- a/content/documentation/customizeTheiaCloud/content.md
+++ b/content/documentation/customizeTheiaCloud/content.md
@@ -70,7 +70,7 @@ A simple use case to start a session with a workspace and automatic redirects lo
 ```ts
 import { LaunchRequest, TheiaCloud } from "@eclipse-theiacloud/common";
 
-const appId = "asdfghjkl"; // the app.id value used when installing the theia-cloud helm chart
+const serviceAuthToken = "asdfghjkl"; // the service.authToken value used when installing the theia-cloud helm chart
 const theiaCloudServiceURL = "https://service.my-domain.io"; // the URL of the rest service
 const appDefinition = "theia-cloud-demo"; // which app to start
 const timeout = 5;
@@ -79,7 +79,7 @@ const workspaceName = "my-workspace";
 TheiaCloud.launchAndRedirect(
   LaunchRequest.createWorkspace(
     theiaCloudServiceURL,
-    appId,
+    serviceAuthToken,
     appDefinition,
     timeout,
     userEmail,

--- a/content/documentation/setupTheiaCloud/content.md
+++ b/content/documentation/setupTheiaCloud/content.md
@@ -32,15 +32,44 @@ You may use your existing cluster issuers as well!
 
 We suggest installing the cert-manager using [the official Helm chart](https://cert-manager.io/docs/installation/helm/).
 
-### ingress-nginx
+### Ingress Controller
 
-By default, the ingresses are installed via the Theia Cloud Helm charts and created by the Theia Cloud operator using the [Ingress NGINX Controller](https://kubernetes.github.io/ingress-nginx/).
+Theia Cloud supports two ingress controllers: [HAProxy Ingress](https://haproxy-ingress.github.io/) (default since 1.2) and [Ingress NGINX](https://kubernetes.github.io/ingress-nginx/) (legacy; default until including 1.1). The nginx ingress controller is [being retired upstream](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/), so we recommend HAProxy for new installations.
 
-You can find the official deployment instructions [here](https://kubernetes.github.io/ingress-nginx/deploy/).
+You can configure the controller via the `ingress.controller` value in the `theia-cloud` Helm chart.
 
-**Note:** Since `ingress-nginx` version 1.10 , the annotation `nginx.ingress.kubernetes.io/configuration-snippet` is disabled by default and needs to be enabled. To enable this option, set the `allow-snippet-annotations: "true"` flag in the ingress-nginx values. For example, via the `ingress-nginx-controller`s config-map. For more information see the [documentation](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/)
+#### HAProxy
 
-_Please note that it is possible to integrate other types of ingresses into Theia Cloud as well, and this is part of our roadmap. We do not offer documentation and finalized APIs for this yet, however. If you need this feature sooner, please see our [available support options]({{< relref "/support" >}})._
+The [HAProxy Ingress Controller](https://haproxy-ingress.github.io/) is the default ingress controller for Theia Cloud.
+
+It can be installed using the official Helm chart. The installation instructions are available in the official documentation:
+[https://haproxy-ingress.github.io/docs/getting-started/#installation](https://haproxy-ingress.github.io/docs/getting-started/#installation)
+
+Example:
+
+```sh
+helm repo add haproxy-ingress https://haproxy-ingress.github.io/charts
+helm repo update
+helm install haproxy-ingress haproxy-ingress/haproxy-ingress \
+  --version 0.15.1 \
+  --namespace ingress-haproxy \
+  --create-namespace \
+  --set controller.ingressClassResource.enabled=true
+```
+
+For further details, see the official HAProxy Ingress documentation:
+[https://haproxy-ingress.github.io/docs/](https://haproxy-ingress.github.io/docs/)
+
+#### nginx
+
+The [Ingress NGINX Controller](https://kubernetes.github.io/ingress-nginx/) is still supported, but is [being retired upstream](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/). For new installations, we recommend using HAProxy.
+
+The official deployment instructions are available here:
+[https://kubernetes.github.io/ingress-nginx/deploy/](https://kubernetes.github.io/ingress-nginx/deploy/)
+
+**Note:** Since `ingress-nginx` version 1.10, the annotation `nginx.ingress.kubernetes.io/configuration-snippet` is disabled by default and needs to be enabled. To enable this option, set the `allow-snippet-annotations: "true"` flag in the ingress-nginx values. For example, via the `ingress-nginx-controller`s config-map. For more information see the [documentation](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/).
+
+_Please note that it is possible to integrate other ingress controllers with Theia Cloud. We currently do not provide documentation for this. If you require a different ingress controller, please refer to our [available support options]({{< relref "/support" >}})._
 
 ### Keycloak (optional)
 
@@ -143,6 +172,7 @@ operator:
   cloudProvider: "K8S"
 
 ingress:
+  controller: haproxy # or "nginx" (legacy)
   clusterIssuer: letsencrypt-prod
   theiaCloudCommonName: false
   addTLSSecretName: false
@@ -161,6 +191,10 @@ Customization Instructions:
 - Host Configuration: The `hosts.configuration.baseHost` value has to be set to the hostname you want to use. An easy way to get started could be the public IP of your ingress controller. For example you may get this with:
 
 ```sh
+# For HAProxy:
+kubectl -n ingress-haproxy get service haproxy-ingress -o yaml
+
+# For nginx:
 kubectl -n ingress-nginx get service ingress-nginx-controller -o yaml
 ```
 
@@ -202,6 +236,8 @@ This includes updating values as well as upgrading to a new Theia Cloud version.
 Similar to the installation, Helm is used for this.
 
 Before moving to a new Theia Cloud version, you might want to have a look at the [Theia Cloud Helm changelog](https://github.com/eclipse-theia/theia-cloud-helm/blob/main/CHANGELOG.md). If you customized core components (e.g. the operator), you also might want to look at [Theia Cloud's code changelog](https://github.com/eclipse-theia/theia-cloud/blob/main/CHANGELOG.md).
+
+**Upgrading to 1.2.0:** The nginx ingress path regex pattern changed from `($|(/.*))` to `(/|$)(.*)` and the `rewrite-target` annotation now uses `$1$2` instead of `$1`. This maintains the same functionality but users with custom nginx configurations relying on the capture group numbering may need to adjust. See the [changelog](https://github.com/eclipse-theia/theia-cloud-helm/blob/main/CHANGELOG.md) for details.
 
 Make sure you have the Theia Cloud helm charts available and updated as described in section [Theia Cloud Helm Charts](#theia-cloud-helm-charts).
 In short:

--- a/content/documentation/setupTheiaCloud/content.md
+++ b/content/documentation/setupTheiaCloud/content.md
@@ -34,7 +34,7 @@ We suggest installing the cert-manager using [the official Helm chart](https://c
 
 ### Ingress Controller
 
-Theia Cloud supports two ingress controllers: [HAProxy Ingress](https://haproxy-ingress.github.io/) (default since 1.2) and [Ingress NGINX](https://kubernetes.github.io/ingress-nginx/) (legacy; default until including 1.1). The nginx ingress controller is [being retired upstream](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/), so we recommend HAProxy for new installations.
+Theia Cloud supports two ingress controllers: [HAProxy Ingress](https://haproxy-ingress.github.io/) (default since 1.2) and [Ingress NGINX](https://kubernetes.github.io/ingress-nginx/) (legacy; default until including 1.1). The nginx ingress controller is [being retired upstream](https://www.kubernetes.dev/blog/2025/11/12/ingress-nginx-retirement/), so we recommend HAProxy for new installations.
 
 You can configure the controller via the `ingress.controller` value in the `theia-cloud` Helm chart.
 
@@ -62,7 +62,7 @@ For further details, see the official HAProxy Ingress documentation:
 
 #### nginx
 
-The [Ingress NGINX Controller](https://kubernetes.github.io/ingress-nginx/) is still supported, but is [being retired upstream](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/). For new installations, we recommend using HAProxy.
+The [Ingress NGINX Controller](https://kubernetes.github.io/ingress-nginx/) is still supported, but is [being retired upstream](https://www.kubernetes.dev/blog/2025/11/12/ingress-nginx-retirement/). For new installations, we recommend using HAProxy.
 
 The official deployment instructions are available here:
 [https://kubernetes.github.io/ingress-nginx/deploy/](https://kubernetes.github.io/ingress-nginx/deploy/)
@@ -153,8 +153,10 @@ Begin by creating a `values.yaml` file with your desired configuration, e.g.:
 
 ```yaml
 app:
-  id: asdfghjkl
   name: My Theia
+
+service:
+  authToken: asdfghjkl
 
 demoApplication:
   name: theiacloud/theia-cloud-demo
@@ -186,7 +188,7 @@ servicerole:
 
 Customization Instructions:
 
-- `app.id`: Generate a unique string for `app.id`. This identifier is public, so don't reuse a secret.
+- `service.authToken`: Generate a unique string for `service.authToken`. This token is used in the communication between website and REST-API for spam mitigation. It is public, so don't reuse a secret. (Replaces the deprecated `app.id`.)
 - Image Configuration: `demoApplication.name` allows you to specify a custom Docker image for Theia. Use `demoApplication.timeout` to define the session timeout, after which the application will automatically shut down.
 - Host Configuration: The `hosts.configuration.baseHost` value has to be set to the hostname you want to use. An easy way to get started could be the public IP of your ingress controller. For example you may get this with:
 
@@ -237,7 +239,12 @@ Similar to the installation, Helm is used for this.
 
 Before moving to a new Theia Cloud version, you might want to have a look at the [Theia Cloud Helm changelog](https://github.com/eclipse-theia/theia-cloud-helm/blob/main/CHANGELOG.md). If you customized core components (e.g. the operator), you also might want to look at [Theia Cloud's code changelog](https://github.com/eclipse-theia/theia-cloud/blob/main/CHANGELOG.md).
 
-**Upgrading to 1.2.0:** The nginx ingress path regex pattern changed from `($|(/.*))` to `(/|$)(.*)` and the `rewrite-target` annotation now uses `$1$2` instead of `$1`. This maintains the same functionality but users with custom nginx configurations relying on the capture group numbering may need to adjust. See the [changelog](https://github.com/eclipse-theia/theia-cloud-helm/blob/main/CHANGELOG.md) for details.
+**Upgrading to 1.2.0:**
+- The default ingress controller changed from nginx to HAProxy. Existing deployments using nginx must explicitly set `ingress.controller: "nginx"` in their `theia-cloud` Helm values and `issuerprod.ingressClass: "nginx"` in their `theia-cloud-base` Helm values.
+- `app.id` is deprecated in favor of `service.authToken`. Custom landing pages or tooling referencing `appId` should be updated to use `serviceAuthToken`.
+- The nginx ingress path regex pattern changed from `($|(/.*))` to `(/|$)(.*)` and the `rewrite-target` annotation now uses `$1$2` instead of `$1`. This maintains the same functionality but users with custom nginx configurations relying on the capture group numbering may need to adjust.
+
+See the [changelog](https://github.com/eclipse-theia/theia-cloud-helm/blob/main/CHANGELOG.md) for details.
 
 Make sure you have the Theia Cloud helm charts available and updated as described in section [Theia Cloud Helm Charts](#theia-cloud-helm-charts).
 In short:

--- a/content/documentation/try/gke/content.md
+++ b/content/documentation/try/gke/content.md
@@ -31,7 +31,7 @@ You can download and install Terraform as described here: <https://developer.has
 We expect users to have basic experience with GKE: <https://cloud.google.com/kubernetes-engine>.
 You may want to check their guides as a new user first: <https://cloud.google.com/kubernetes-engine/docs/deploy-app-cluster>
 
-Please note that using our configurations may cause you cost depending ob whether the free credit provided for new GKE users was used up already.
+Please note that using our configurations may cause you cost depending on whether the free credit provided for new GKE users was used up already.
 
 Our terraform modules expect you to have the Google Cloud SDK installed and set up: <https://cloud.google.com/sdk>
 
@@ -64,12 +64,18 @@ terraform init
 terraform apply
 ```
 
+_By default, HAProxy is used as the ingress controller. To use the legacy nginx controller instead, pass the `ingress_controller_type` variable:_
+
+```bash
+terraform apply -var="ingress_controller_type=nginx"
+```
+
 This will now run for a few minutes. During this time it will
 
 - Create a GKE cluster named `gke-theia-cloud-getting-started`
 - Install a number of tools in the cluster using helm
   - cert-manager for managing Certificates
-  - nginx-ingress-controller for exposing HTTP(S) routes via NginX
+  - an ingress controller for exposing HTTP(S) routes (HAProxy by default; nginx is also supported)
   - Keycloak for managing authentication
   - Theia Cloud
 - Creates a few default users on Keycloak

--- a/content/documentation/try/minikube/content.md
+++ b/content/documentation/try/minikube/content.md
@@ -56,25 +56,49 @@ git clone https://github.com/eclipse-theia/theia-cloud.git
 
 #### Run the Getting Started Guide
 
-Now, we may finally create our local cluster and install Theia Cloud including all of its dependencies. With our terraform configuration this may be done with just a few commands on the terminal:
+Now, we may finally create our local cluster and install Theia Cloud including all of its dependencies. The setup is split into two steps.
+
+##### Step 0: Create the Minikube Cluster
 
 ```bash
 # cd into the checked out theia-cloud directory, from there:
-cd terraform/configurations/minikube_getting_started/
+cd terraform/configurations/minikube_getting_started/0_minikube_getting_started
 
 # download required providers
 terraform init
 
 # create the cluster
-# You will be asked for an email address used by the cert-manager to contact you about expiring certs.
-# Enter yes at the end
 terraform apply
 ```
 
-_By default, HAProxy is used as the ingress controller. To use the legacy nginx controller instead, pass the `ingress_controller_type` variable:_
+_To use the legacy nginx controller instead of HAProxy, pass the `ingress_controller_type` variable:_
 
 ```bash
 terraform apply -var="ingress_controller_type=nginx"
+```
+
+##### Step 1: Install Theia Cloud and Dependencies
+
+By default, HAProxy is used as the ingress controller. HAProxy requires `minikube tunnel` to be running. Open a new terminal and start the tunnel before running step 1, and keep it running throughout the session:
+
+```bash
+minikube tunnel
+```
+
+_If you chose the nginx ingress controller in Step 0, `minikube tunnel` is not required._
+
+Then, in your original terminal:
+
+```bash
+cd ../1_theiacloud-and-dependencies
+
+# download required providers
+terraform init
+
+# install Theia Cloud and all dependencies
+# You will be asked for an email address used by the cert-manager to contact you about expiring certs.
+# Enter yes at the end
+terraform apply
 ```
 
 This will now run for a few minutes. During this time it will
@@ -99,9 +123,9 @@ Outputs:
 try_now = "https://192.168.59.105.nip.io/trynow/"
 ```
 
-Point your browser to the “try_now” URL and accept the self signed certificate.\
+Point your browser to the "try_now" URL and accept the self signed certificate.\
 This will then redirect you to Keycloak where you may login using one of the two users above.\
-After successful authentication a sample “Eclipse Theia IDE” will be launched for you.
+After successful authentication a sample "Eclipse Theia IDE" will be launched for you.
 
 #### Troubleshooting
 
@@ -109,7 +133,7 @@ This section covers common pitfalls that were reported to us.
 
 ##### How to use a Minikube driver other than Virtualbox
 
-In order to try a different driver than Virtualbox open `terraform/configurations/minikube_getting_started/minikube_getting_started.tf` and adjust
+In order to try a different driver than Virtualbox open `terraform/configurations/minikube_getting_started/0_minikube_getting_started/main.tf` and adjust
 
 ```bash
 driver       = "virtualbox"

--- a/content/documentation/try/minikube/content.md
+++ b/content/documentation/try/minikube/content.md
@@ -71,12 +71,18 @@ terraform init
 terraform apply
 ```
 
+_By default, HAProxy is used as the ingress controller. To use the legacy nginx controller instead, pass the `ingress_controller_type` variable:_
+
+```bash
+terraform apply -var="ingress_controller_type=nginx"
+```
+
 This will now run for a few minutes. During this time it will
 
 - Create a Virtualbox VM running the Kubernetes Cluster
 - Install a number of tools in the cluster using helm
   - cert-manager for managing Certificates
-  - nginx-ingress-controller for exposing HTTP(S) routes via NginX
+  - an ingress controller for exposing HTTP(S) routes (HAProxy by default; nginx is also supported)
   - keycloak for managing authentication
   - Theia Cloud
 - Creates a few default users on Keycloak


### PR DESCRIPTION
**Merge with 1.2 release**

* Update Theia Cloud setup docs to cover HAProxy (default) and legacy nginx ingress controllers
* Adjust GKE and minikube getting started docs to mention the ingress controller option and Terraform variable

related
https://github.com/eclipse-theia/theia-cloud/pull/483
https://github.com/eclipse-theia/theia-cloud-helm/pull/105